### PR TITLE
Replace stub/virtualize usage with mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Upon receiving a message, the consumer processes it and publishes a new message 
 
 ## Get information around other CLI args exposed by specmatic-kafka docker image
 
-1. To get information around all the CLI args of the `virtualize` command, run the following.
+1. To get information around all the CLI args of the `mock` command, run the following.
    ```shell
-    docker run specmatic/specmatic-kafka virtualize --help
+    docker run specmatic/specmatic-kafka mock --help
    ```
 2. To get information around all the CLI args of the `test` command, run the following.
    ```shell


### PR DESCRIPTION
## Summary
- replace remaining Specmatic command usage of \ and \ with \
- update test-container startup checks to match mock server logs where applicable

## Validation
- searched codebase for remaining command-form usage of \Using bleeding edge Specmatic build

Error: No jar file found matching pattern: /Users/naresh/projects/specmatic-all/specmatic/application/build/libs/specmatic*-all-un*.jar and \