### PR TITLE
Surface testcontainers root cause on test failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,7 @@ repositories {
 }
 
 dependencies {
-    implementation ('org.springframework.boot:spring-boot-starter') {
-        exclude group: 'ch.qos.logback', module: 'logback-classic'
-    }
+    implementation 'org.springframework.boot:spring-boot-starter'
     implementation ('org.springframework.kafka:spring-kafka:3.3.16') {
         exclude group: 'org.lz4', module: 'lz4-java'
     }
@@ -43,4 +41,11 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    testLogging {
+        // Pipe the forked test JVM's stdout/stderr (logback output, Testcontainers logs)
+        // into the Gradle console; otherwise it only lands in the HTML report.
+        showStandardStreams = true
+        exceptionFormat = 'full'
+        showStackTraces = true
+    }
 }

--- a/src/test/kotlin/com/example/order/ContractTestUsingTestContainer.kt
+++ b/src/test/kotlin/com/example/order/ContractTestUsingTestContainer.kt
@@ -1,14 +1,19 @@
 package com.example.order
 
+import io.specmatic.testcontainers.UnhealthyContainerHealthcheckLogger
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.condition.EnabledIf
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.slf4j.LoggerFactory
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.kafka.test.context.EmbeddedKafka
 import org.springframework.test.annotation.DirtiesContext
+import org.testcontainers.DockerClientFactory
 import org.testcontainers.containers.BindMode
 import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.output.Slf4jLogConsumer
 import org.testcontainers.containers.wait.strategy.Wait
 
 @SpringBootTest
@@ -34,6 +39,12 @@ import org.testcontainers.containers.wait.strategy.Wait
 class ContractTestUsingTestContainer {
 
     companion object {
+        private val logger = LoggerFactory.getLogger(ContractTestUsingTestContainer::class.java)
+
+        @JvmField
+        @RegisterExtension
+        val unhealthyContainerHealthchecks = UnhealthyContainerHealthcheckLogger(dockerClient = DockerClientFactory.instance().client())
+
         @JvmStatic
         fun isNonCIOrLinux(): Boolean =
             System.getenv("CI") != "true" || System.getProperty("os.name").lowercase().contains("linux")
@@ -45,7 +56,7 @@ class ContractTestUsingTestContainer {
             .withFileSystemBind("./", "/usr/src/app", BindMode.READ_WRITE)
             .waitingFor(Wait.forLogMessage(".*Failed:.*", 1))
             .withNetworkMode("host")
-            .withLogConsumer { print(it.utf8String) }
+            .withLogConsumer(Slf4jLogConsumer(logger))
 
 
     @Test

--- a/src/test/kotlin/io/specmatic/testcontainers/UnhealthyContainerHealthcheckLogger.kt
+++ b/src/test/kotlin/io/specmatic/testcontainers/UnhealthyContainerHealthcheckLogger.kt
@@ -1,0 +1,91 @@
+package io.specmatic.testcontainers
+
+import com.github.dockerjava.api.DockerClient
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.InvocationInterceptor
+import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext
+import org.slf4j.LoggerFactory
+import java.lang.reflect.Method
+
+class UnhealthyContainerHealthcheckLogger(val dockerClient: DockerClient) : InvocationInterceptor {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun interceptBeforeAllMethod(
+        invocation: Invocation<Void>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext,
+    ) {
+        invocation.dumpHealthchecksOnFailure()
+    }
+
+    override fun interceptBeforeEachMethod(
+        invocation: Invocation<Void>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext,
+    ) {
+        invocation.dumpHealthchecksOnFailure()
+    }
+
+    override fun interceptTestMethod(
+        invocation: Invocation<Void>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext,
+    ) {
+        invocation.dumpHealthchecksOnFailure()
+    }
+
+    override fun interceptTestTemplateMethod(
+        invocation: Invocation<Void>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext,
+    ) {
+        invocation.dumpHealthchecksOnFailure()
+    }
+
+    override fun interceptAfterEachMethod(
+        invocation: Invocation<Void>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext,
+    ) {
+        invocation.dumpHealthchecksOnFailure()
+    }
+
+    override fun interceptAfterAllMethod(
+        invocation: Invocation<Void>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext,
+    ) {
+        invocation.dumpHealthchecksOnFailure()
+    }
+
+    private fun <T> Invocation<T>.dumpHealthchecksOnFailure(): T {
+        try {
+            return proceed()
+        } catch (e: Throwable) {
+            val unhealthyContainerLogs = logUnhealthyContainerHealthchecks()
+            if (unhealthyContainerLogs.isEmpty()) throw e
+            throw UnhealthyContainerException(unhealthyContainerLogs.joinToString("\n\n"), e)
+        }
+    }
+
+    private fun logUnhealthyContainerHealthchecks(): List<String> {
+        val unhealthy = dockerClient.listContainersCmd()
+            .withShowAll(true)
+            .withFilter("health", listOf("unhealthy"))
+            .exec()
+        return unhealthy.map { container ->
+            val name = container.names.firstOrNull()?.trimStart('/') ?: container.id
+            val healthLog = dockerClient.inspectContainerCmd(container.id).exec()
+                .state.health?.log.orEmpty()
+                .joinToString("\n") { "[exit=${it.exitCodeLong}] ${it.output?.trim()}" }
+            val message = "Healthcheck output for unhealthy container '$name':\n$healthLog"
+            logger.error(message)
+            message
+        }
+    }
+
+    private class UnhealthyContainerException(message: String, cause: Throwable) : Exception(message, cause) {
+        override fun fillInStackTrace(): Throwable = this
+    }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Ports the reusable testcontainers failure-diagnostics from specmatic/specmatic-kafka-avro-sample#102 + #103. When a test fails, the underlying cause is now surfaced in the FAILED summary instead of an opaque `ContainerLaunchException`.

- **`UnhealthyContainerHealthcheckLogger`** — JUnit 5 extension that, on failure, dumps the healthcheck output of any `unhealthy` Docker container. Attached as the exception **cause** (not suppressed), since Gradle does not serialize suppressed exceptions across the test-worker boundary.
- **`build.gradle`** — `testLogging { showStandardStreams; exceptionFormat 'full'; showStackTraces }` so the cause chain prints; dropped the `logback-classic` exclude so logback is on the test classpath.
- **`logback-test.xml`** — console appender at INFO.
- **Test class** — registers the extension; swaps `print(...)` for `Slf4jLogConsumer`.

Repo-specific bits from the source PRs do not apply here: this repo's compose file has no healthchecks, so the `retries` timing change and the schema-registry healthcheck fix are omitted.